### PR TITLE
Use waitid in WaitContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/mdlayher/socket v0.2.3
-	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8
+	golang.org/x/sys v0.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cO
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pidfd.go
+++ b/pidfd.go
@@ -5,10 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
-	"sync/atomic"
 	"syscall"
-	"time"
 )
 
 // A File is a handle to a Linux pidfd. If the process referred to by the pidfd
@@ -38,65 +35,7 @@ func (f *File) SendSignal(signal os.Signal) error {
 // Wait waits for the process referred to by File to exit. If the context is
 // canceled, Wait will unblock and return an error.
 func (f *File) Wait(ctx context.Context) error {
-	// Wait for the poller to indicate readiness, unless the context is canceled
-	// first. For values of n:
-	//  - 0: init
-	//  - 1: callback invoked, wait for process exit
-	//  - 2: callback invoked due to process exit, stop waiting
-	var n uint32
-	return f.readContext(ctx, func(_ uintptr) bool {
-		return atomic.AddUint32(&n, 1) == 2
-	})
-}
-
-// TODO(mdlayher): move into socket.Conn?
-
-// readContext invokes fn, a read function which indicates readiness, against
-// the associated file descriptor. readContext will block until the read
-// function returns true or the context is canceled. If a context error occurs,
-// it supersedes all other errors returned by this function.
-func (f *File) readContext(ctx context.Context, fn func(fd uintptr) bool) error {
-	// To observe context cancelation, we will set a past deadline in a
-	// goroutine to force blocked Reads to unblock.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	defer wg.Wait()
-
-	go func() {
-		defer wg.Done()
-
-		// Immediately unblock pending reads.
-		<-ctx.Done()
-		_ = f.c.SetReadDeadline(time.Unix(0, 1))
-	}()
-
-	rerr := f.rc.Read(func(fd uintptr) bool {
-		if ctx.Err() != nil {
-			// Context canceled, don't invoke user function.
-			return true
-		}
-
-		return fn(fd)
-	})
-
-	// The operation has unblocked. Observe context cancelation, tidy up the
-	// cancelation goroutine, and disarm the read deadline timer.
-	cerr := ctx.Err()
-	cancel()
-	wg.Wait()
-	serr := f.c.SetReadDeadline(time.Time{})
-
-	// Context cancel takes priority over all other errors.
-	for _, err := range []error{cerr, rerr, serr} {
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return f.wait(ctx)
 }
 
 // Ensure compatibility with package errors.

--- a/pidfd_others.go
+++ b/pidfd_others.go
@@ -3,6 +3,7 @@
 package pidfd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -20,6 +21,7 @@ func open(_ int) (*File, error) { return nil, errUnimplemented }
 type conn struct{}
 
 func (*File) sendSignal(_ os.Signal) error { return errUnimplemented }
+func (*File) wait(_ context.Context) error { return errUnimplemented }
 
 func (*conn) Close() error                      { return errUnimplemented }
 func (*conn) SetReadDeadline(_ time.Time) error { return errUnimplemented }


### PR DESCRIPTION
`WaitContext` doesn't reap the process (as before) thanks to `WNOWAIT` flag. In the future, it might make sense to customize this behaviour.

Closes #1